### PR TITLE
fix: use GH_PAT for org-level project board access

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,15 +12,16 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      repository-projects: write
       contents: read
+      # Organization projects require org-level token
+      # Using GH_PAT secret for org-wide access
 
     steps:
       - name: Add to project board
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Fused-Gaming/projects/10
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           labeled: "🚨Priority:CRITICAL, 🔴Priority:HIGH, type: goal-proposal, type: project-proposal, ❎GOVERNANCE"
           label-operator: OR
 
@@ -28,7 +29,7 @@ jobs:
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Fused-Gaming/projects/10
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           labeled: "2026, quarter: Q1, quarter: Q2, quarter: Q3, quarter: Q4"
           label-operator: OR
 


### PR DESCRIPTION
## Problem
The `add-to-project` workflow was failing with the error:
```
Could not resolve to a ProjectV2 with the number 10
```

This happens because organization-level GitHub Projects require organization-wide permissions that the default `GITHUB_TOKEN` doesn't have.

## Solution
- Updated workflow to use `GH_PAT` secret (with fallback to `GITHUB_TOKEN`)
- Added explanatory comments about org-level token requirements
- Removed `repository-projects` permission (not applicable for org projects)

## Testing
The workflow will be tested when:
1. An issue is opened/labeled with strategic labels
2. A PR is opened/labeled with strategic labels

Note: This requires the `GH_PAT` secret to be configured in the repository settings (see issue #2 from the governance milestone).

## Checklist
- [x] Branch created from development
- [x] Workflow file updated with GH_PAT usage
- [x] Commit message follows convention
- [x] Changes pushed to origin
- [ ] PR created
- [ ] Workflow tested (will test after merge or with test issue)
- [ ] PR merged to development

Fixes: #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)