### PR TITLE
Merge development to master (workflow fix)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,15 +12,16 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      repository-projects: write
       contents: read
+      # Organization projects require org-level token
+      # Using GH_PAT secret for org-wide access
 
     steps:
       - name: Add to project board
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Fused-Gaming/projects/10
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           labeled: "🚨Priority:CRITICAL, 🔴Priority:HIGH, type: goal-proposal, type: project-proposal, ❎GOVERNANCE"
           label-operator: OR
 
@@ -28,7 +29,7 @@ jobs:
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Fused-Gaming/projects/10
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           labeled: "2026, quarter: Q1, quarter: Q2, quarter: Q3, quarter: Q4"
           label-operator: OR
 


### PR DESCRIPTION
Merging the workflow fix from development to master so the add-to-project workflow can run correctly.

This PR contains:
- Fix for add-to-project workflow to use GH_PAT for org-level project access

Once merged, the workflow should successfully add issues/PRs to Project #10.

Related: #28, Fixes: #72