### PR TITLE
docs: clarify GH_PAT scope requirements for Projects V2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,8 +13,9 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-      # Organization projects require org-level token
-      # Using GH_PAT secret for org-wide access
+      # Organization projects (ProjectsV2) require org-level token with 'project' scope
+      # GH_PAT secret must have: repo, read:org, read:project, write:project
+      # See: https://github.com/Fused-Gaming/.github/issues/2
 
     steps:
       - name: Add to project board


### PR DESCRIPTION
## Problem
Testing revealed that the workflow is failing with:
```
Resource not accessible by personal access token
```

This means `GH_PAT` exists (likely at org level) but doesn't have the required scopes for organization-level GitHub Projects (ProjectsV2).

## Solution
Updated the workflow comments to clarify the **exact scopes required**:
- `repo` (for repository access)
- `read:org` (for organization access)  
- `read:project` (for reading Projects V2)
- `write:project` (for writing to Projects V2)

## Impact
This is a documentation-only change. The workflow code remains the same but now has clearer guidance for configuring the `GH_PAT` secret.

## Next Steps
The `GH_PAT` secret needs to be updated/recreated with the correct scopes as outlined in Issue #2.

Related: #72, #2