### PR TITLE
docs: merge updated GH_PAT scope documentation to master

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,8 +13,9 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-      # Organization projects require org-level token
-      # Using GH_PAT secret for org-wide access
+      # Organization projects (ProjectsV2) require org-level token with 'project' scope
+      # GH_PAT secret must have: repo, read:org, read:project, write:project
+      # See: https://github.com/Fused-Gaming/.github/issues/2
 
     steps:
       - name: Add to project board


### PR DESCRIPTION
Merging the updated workflow documentation from development to master.

Changes:
- Clarified GH_PAT scope requirements for Projects V2
- Added specific scopes needed: repo, read:org, read:project, write:project

This ensures the workflow comments accurately reflect what's needed to fix the add-to-project workflow.

Related: #72, #2, #34